### PR TITLE
82 multi criteria weighting run number bug fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,6 @@ Suggests:
     testthat (>= 3.0.0)
 Remotes:
     github::JGCRI/hector
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/R/multi_criteria_weighting.R
+++ b/R/multi_criteria_weighting.R
@@ -60,9 +60,12 @@ multi_criteria_weighting <- function(scores_list, criterion_weights = NULL) {
   # normalize the combined weights to sum to 1
   normalized_combined_scores <- combined_scores / sum(combined_scores)
 
+  # extract run_numbers from one of the data frames in scores_list
+  run_numbers <- scores_list[[1]]$run_number
+
   # return a df with run number and normalized multi-criteria weights
   return(data.frame(
-    run_number = 1:length(normalized_combined_scores),
+    run_number = run_numbers,
     mc_weight = normalized_combined_scores
   ))
 }

--- a/R/multi_criteria_weighting.R
+++ b/R/multi_criteria_weighting.R
@@ -12,9 +12,9 @@
 #'
 #' @examples
 #' # Data frames representing scored ensemble using different scoring criterion
-#' score_df1 <- data.frame(weights = c(0.8, 0.6, 0.9))
-#' score_df2 <- data.frame(weights = c(0.7, 0.5, 0.8))
-#' score_df3 <- data.frame(weights = c(0.9, 0.8, 0.7))
+#' score_df1 <- data.frame(run_number = c(1, 2, 3), weights = c(0.8, 0.6, 0.9))
+#' score_df2 <- data.frame(run_number = c(1, 2, 3), weights = c(0.7, 0.5, 0.8))
+#' score_df3 <- data.frame(run_number = c(1, 2, 3), weights = c(0.9, 0.8, 0.7))
 #'
 #' # List of score data frames
 #' scores_list <- list(score_df1, score_df2, score_df3)

--- a/man/multi_criteria_weighting.Rd
+++ b/man/multi_criteria_weighting.Rd
@@ -23,9 +23,9 @@ Weighting ensemble members using multiple criterion
 }
 \examples{
 # Data frames representing scored ensemble using different scoring criterion
-score_df1 <- data.frame(weights = c(0.8, 0.6, 0.9))
-score_df2 <- data.frame(weights = c(0.7, 0.5, 0.8))
-score_df3 <- data.frame(weights = c(0.9, 0.8, 0.7))
+score_df1 <- data.frame(run_number = c(1, 2, 3), weights = c(0.8, 0.6, 0.9))
+score_df2 <- data.frame(run_number = c(1, 2, 3), weights = c(0.7, 0.5, 0.8))
+score_df3 <- data.frame(run_number = c(1, 2, 3), weights = c(0.9, 0.8, 0.7))
 
 # List of score data frames
 scores_list <- list(score_df1, score_df2, score_df3)

--- a/tests/testthat/test-multi_criterion_weighting.R
+++ b/tests/testthat/test-multi_criterion_weighting.R
@@ -1,7 +1,10 @@
 # Sample data
-score_df1 <- data.frame(weights = c(0.6, 0.4))
-score_df2 <- data.frame(weights = c(0.5, 0.5))
-score_df3 <- data.frame(weights = c(0.9, 0.1))
+score_df1 <- data.frame(run_number = c(1, 2),
+                        weights = c(0.6, 0.4))
+score_df2 <- data.frame(run_number = c(1, 2),
+                        weights = c(0.5, 0.5))
+score_df3 <- data.frame(run_number = c(1, 2),
+                        weights = c(0.9, 0.1))
 
 # Sample lists
 L1 <- list()


### PR DESCRIPTION
This commit corrects the run_number problem in `multi_criteria_weighting` by copying run_numbers from one of the score data frames included in the score list. This way if NAs are omitted from the score data frames, that is copied over to the result of `multi_criteria_weighting`